### PR TITLE
Add Criterion benchmark for pipeline processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ image = "0.25.6"
 imgref = "1.11.0"
 kolor = "0.1.9"
 rayon = "1.10.0"
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "pi_camera_benchmark"
+harness = false

--- a/benches/pi_camera_benchmark.rs
+++ b/benches/pi_camera_benchmark.rs
@@ -1,0 +1,24 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use sienna::{ProcessingImage, builder::PipelineBuilder};
+use std::path::Path;
+
+fn process_pi_hq(c: &mut Criterion) {
+    let pipeline = PipelineBuilder::new()
+        .exposure(0.5)
+        .richness(0.3)
+        .film_colors()
+        .contrast(1.2, 0.6)
+        .build();
+
+    c.bench_function("process_pi_hq_photo", |b| {
+        b.iter(|| {
+            let path = Path::new("samples/pi.png");
+            let mut image = ProcessingImage::from_png(path).expect("failed to load image");
+            pipeline.process(&mut image);
+            black_box(image);
+        })
+    });
+}
+
+criterion_group!(benches, process_pi_hq);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add Criterion dev-dependency and bench configuration
- benchmark pipeline stages on `samples/pi.png`

## Testing
- `cargo test` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `cargo bench` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68b8df32392c8331b5c8ff18edc76f97